### PR TITLE
CI: setup R CMD check and coverage

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,52 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+          error-on: '"error"'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,62 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+name: test-coverage.yaml
+
+permissions: read-all
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/shikokuchuo/automerge-r/graph/badge.svg)](https://app.codecov.io/gh/shikokuchuo/automerge-r)
 <!-- badges: end -->
 
 R Bindings for the Automerge CRDT Library

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 # automerge
 
 <!-- badges: start -->
+[![R-CMD-check](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 R Bindings for the Automerge CRDT Library

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml)
+[![Codecov test
+coverage](https://codecov.io/gh/shikokuchuo/automerge-r/graph/badge.svg)](https://app.codecov.io/gh/shikokuchuo/automerge-r)
 <!-- badges: end -->
 
 R Bindings for the Automerge CRDT Library
@@ -73,7 +75,7 @@ doc$age <- 20L
 doc[["active"]] <- TRUE
 doc
 #> <Automerge Document>
-#> Actor: 9be48f3b7463d06f34b1d11d9708b3fb 
+#> Actor: 40b2c02a11b397ce63f3b20260d9c4a6 
 #> Root keys: 3 
 #> Keys: active, age, name
 ```
@@ -154,7 +156,7 @@ as.list(doc) # Convert to R list
 #> [1] 20
 #> 
 #> $created
-#> [1] "2025-11-21 19:23:34 GMT"
+#> [1] "2025-11-21 21:27:22 GMT"
 #> 
 #> $name
 #> [1] "Alice"
@@ -197,7 +199,7 @@ str(bytes)
 doc2 <- am_load(bytes)
 doc2
 #> <Automerge Document>
-#> Actor: 172337403f1785d0b9df8e43f2efc38c 
+#> Actor: 73e24f46aac44f0ca0f161352fadddae 
 #> Root keys: 7 
 #> Keys: active, age, created, name, notes, score, user
 ```
@@ -225,7 +227,7 @@ am_put(doc, AM_ROOT, "name", "Alice")
 am_put(doc, AM_ROOT, "age", 20L)
 doc
 #> <Automerge Document>
-#> Actor: d085afd2d3aaa6bd530269d7d9b351f3 
+#> Actor: 30fd8db35ed7fc4efafbec341d8e8c7b 
 #> Root keys: 2 
 #> Keys: age, name
 ```
@@ -260,12 +262,12 @@ cat("Synced in", result$rounds, "rounds\n")
 # Both documents now have all keys
 doc1
 #> <Automerge Document>
-#> Actor: d8c083c1838a62f03612dd8d601b6e9a 
+#> Actor: c876dd6374e7b9260c3f7cb48d62742a 
 #> Root keys: 4 
 #> Keys: a, b, x, y
 doc2
 #> <Automerge Document>
-#> Actor: ef30873560cb902846a57980a5ecaca4 
+#> Actor: b35a314493b0c738f9f328b59c963ba1 
 #> Root keys: 4 
 #> Keys: a, b, x, y
 ```
@@ -296,18 +298,18 @@ am_commit(doc2, "Bob's changes")
 am_sync_bidirectional(doc1, doc2)
 #> $doc1
 #> <Automerge Document>
-#> Actor: bf51d9d5fedf507f7680a8f9277e71a6 
+#> Actor: 38b6cf2505a2cf75fca0fc17b6d78274 
 #> Root keys: 2 
 #> Keys: counter, edited_by 
 #> 
 #> $doc2
 #> <Automerge Document>
-#> Actor: 52c653554ec88686a57ca102a7d4a63a 
+#> Actor: 9d03c194b42e281c4adfd90f34a64482 
 #> Root keys: 2 
 #> Keys: counter, edited_by 
 #> 
 #> $rounds
-#> [1] 4
+#> [1] 5
 #> 
 #> $converged
 #> [1] TRUE
@@ -388,12 +390,12 @@ while (!is.null(response)) {
 # Documents after sync
 doc1
 #> <Automerge Document>
-#> Actor: 686bb01acbb29e9a258ee5cacb2b3dcf 
+#> Actor: fd2453d3dbb4c1092b9d237782223b20 
 #> Root keys: 3 
 #> Keys: from_doc1, from_doc2, priority
 doc2
 #> <Automerge Document>
-#> Actor: f7441200a275511ea6e66301213a2f2c 
+#> Actor: 664a71bb523fe0ea1eab12166d4297f2 
 #> Root keys: 3 
 #> Keys: from_doc1, from_doc2, priority
 ```
@@ -440,7 +442,7 @@ doc2$additional_analysis <- list(median = 41, iqr = 8)
 am_commit(doc2)
 doc2
 #> <Automerge Document>
-#> Actor: 6d40efa1ca96fba09f7d1cbe75250f90 
+#> Actor: e17d3b442844789d1431ce6aa01cffc6 
 #> Root keys: 2 
 #> Keys: additional_analysis, results
 ```
@@ -463,13 +465,13 @@ am_commit(doc_b, "Model B results")
 am_sync_bidirectional(doc_a, doc_b)
 #> $doc1
 #> <Automerge Document>
-#> Actor: b1aa3bba69377f28dae963aadb012b4f 
+#> Actor: b3393ec9f392f049bd77b739cd0b331d 
 #> Root keys: 2 
 #> Keys: model_a, model_b 
 #> 
 #> $doc2
 #> <Automerge Document>
-#> Actor: 9f378cf623e098953914a326521a406e 
+#> Actor: 6013da91127e8489f859c0b13c503645 
 #> Root keys: 2 
 #> Keys: model_a, model_b 
 #> 
@@ -507,13 +509,13 @@ am_commit(central_doc, "Central data")
 am_sync_bidirectional(offline_doc, central_doc)
 #> $doc1
 #> <Automerge Document>
-#> Actor: 0f24be0fac2cc6954cdb5f5f9dc547ea 
+#> Actor: 88603aabe04ef6d3bbff4d914566f9de 
 #> Root keys: 2 
 #> Keys: field_data, processed_data 
 #> 
 #> $doc2
 #> <Automerge Document>
-#> Actor: e7aab221aef882f63f7e4485da571cac 
+#> Actor: f90a5ab2d7e4df48a818f570fee7f5bd 
 #> Root keys: 2 
 #> Keys: field_data, processed_data 
 #> 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 <!-- badges: start -->
 
+[![R-CMD-check](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/shikokuchuo/automerge-r/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 R Bindings for the Automerge CRDT Library
@@ -72,7 +73,7 @@ doc$age <- 20L
 doc[["active"]] <- TRUE
 doc
 #> <Automerge Document>
-#> Actor: 51b3b8898fa52e6fad449529cc8c1fa0 
+#> Actor: 9be48f3b7463d06f34b1d11d9708b3fb 
 #> Root keys: 3 
 #> Keys: active, age, name
 ```
@@ -153,7 +154,7 @@ as.list(doc) # Convert to R list
 #> [1] 20
 #> 
 #> $created
-#> [1] "2025-11-21 15:48:49 GMT"
+#> [1] "2025-11-21 19:23:34 GMT"
 #> 
 #> $name
 #> [1] "Alice"
@@ -196,7 +197,7 @@ str(bytes)
 doc2 <- am_load(bytes)
 doc2
 #> <Automerge Document>
-#> Actor: 307702d2b62b3891ea072878360bc465 
+#> Actor: 172337403f1785d0b9df8e43f2efc38c 
 #> Root keys: 7 
 #> Keys: active, age, created, name, notes, score, user
 ```
@@ -224,7 +225,7 @@ am_put(doc, AM_ROOT, "name", "Alice")
 am_put(doc, AM_ROOT, "age", 20L)
 doc
 #> <Automerge Document>
-#> Actor: d2b73097446fb75cf1532dd6d6d4770e 
+#> Actor: d085afd2d3aaa6bd530269d7d9b351f3 
 #> Root keys: 2 
 #> Keys: age, name
 ```
@@ -259,12 +260,12 @@ cat("Synced in", result$rounds, "rounds\n")
 # Both documents now have all keys
 doc1
 #> <Automerge Document>
-#> Actor: ef20d1f6d3bbc930c3d1f37ee4772f94 
+#> Actor: d8c083c1838a62f03612dd8d601b6e9a 
 #> Root keys: 4 
 #> Keys: a, b, x, y
 doc2
 #> <Automerge Document>
-#> Actor: 09d7f851645747528aab9f5d1662457e 
+#> Actor: ef30873560cb902846a57980a5ecaca4 
 #> Root keys: 4 
 #> Keys: a, b, x, y
 ```
@@ -295,13 +296,13 @@ am_commit(doc2, "Bob's changes")
 am_sync_bidirectional(doc1, doc2)
 #> $doc1
 #> <Automerge Document>
-#> Actor: 129f21bf0fca1179fc98b0059d7dc029 
+#> Actor: bf51d9d5fedf507f7680a8f9277e71a6 
 #> Root keys: 2 
 #> Keys: counter, edited_by 
 #> 
 #> $doc2
 #> <Automerge Document>
-#> Actor: 4b45648eb68b5ecb6675bf1be6847148 
+#> Actor: 52c653554ec88686a57ca102a7d4a63a 
 #> Root keys: 2 
 #> Keys: counter, edited_by 
 #> 
@@ -387,12 +388,12 @@ while (!is.null(response)) {
 # Documents after sync
 doc1
 #> <Automerge Document>
-#> Actor: f77d06eb7ed6827ee2ccae1927520062 
+#> Actor: 686bb01acbb29e9a258ee5cacb2b3dcf 
 #> Root keys: 3 
 #> Keys: from_doc1, from_doc2, priority
 doc2
 #> <Automerge Document>
-#> Actor: 80a4a908a7c8fb79c75c9e98b638dea7 
+#> Actor: f7441200a275511ea6e66301213a2f2c 
 #> Root keys: 3 
 #> Keys: from_doc1, from_doc2, priority
 ```
@@ -439,7 +440,7 @@ doc2$additional_analysis <- list(median = 41, iqr = 8)
 am_commit(doc2)
 doc2
 #> <Automerge Document>
-#> Actor: 4561bd4f0dfd9141ce94b55b3c008190 
+#> Actor: 6d40efa1ca96fba09f7d1cbe75250f90 
 #> Root keys: 2 
 #> Keys: additional_analysis, results
 ```
@@ -462,13 +463,13 @@ am_commit(doc_b, "Model B results")
 am_sync_bidirectional(doc_a, doc_b)
 #> $doc1
 #> <Automerge Document>
-#> Actor: 26625ebef0e47473ca4045875782c1eb 
+#> Actor: b1aa3bba69377f28dae963aadb012b4f 
 #> Root keys: 2 
 #> Keys: model_a, model_b 
 #> 
 #> $doc2
 #> <Automerge Document>
-#> Actor: 0ed21c7d5e9bb714b067d3e22b61395c 
+#> Actor: 9f378cf623e098953914a326521a406e 
 #> Root keys: 2 
 #> Keys: model_a, model_b 
 #> 
@@ -506,13 +507,13 @@ am_commit(central_doc, "Central data")
 am_sync_bidirectional(offline_doc, central_doc)
 #> $doc1
 #> <Automerge Document>
-#> Actor: abeeaf64b1489e5056c1eb1ddc6361af 
+#> Actor: 0f24be0fac2cc6954cdb5f5f9dc547ea 
 #> Root keys: 2 
 #> Keys: field_data, processed_data 
 #> 
 #> $doc2
 #> <Automerge Document>
-#> Actor: f1f6df49403dd83e489d2c69ba6d3c67 
+#> Actor: e7aab221aef882f63f7e4485da571cac 
 #> Root keys: 2 
 #> Keys: field_data, processed_data 
 #> 

--- a/configure.win
+++ b/configure.win
@@ -76,6 +76,9 @@ if [ ${AUTOMERGE_FOUND} -eq 0 ]; then
     export TMPDIR="${PWD}/automerge-build/tmp"
     mkdir -p "$TMPDIR"
 
+    # Force GNU target to match MinGW toolchain from Rtools
+    export RUSTUP_TOOLCHAIN="stable-x86_64-pc-windows-gnu"
+
     # UTF-32 code point indexing for natural R character semantics
     # This makes text positions match R's substr(), nchar() behaviour
     echo "Configuring with CMake..."


### PR DESCRIPTION
- R CMD check set to fail on error, not warning (to avoid complaint about downloading Rust crates)
- R CMD check currently failing on Windows due to Rust toolchain