### PR TITLE
CI: disable cache

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          cache: false
 
       - uses: r-lib/actions/check-r-package@v2
         with:


### PR DESCRIPTION
Sporadic CI failures on MacOS due to the workflow rather than the package:

> Error: The template is not valid. r-lib/actions/v2/setup-r-dependencies/action.yaml (Line: 204, Col: 16): hashFiles('./.github/pkg.lock') failed. Fail to hash files under directory '/Users/runner/work/automerge-r/automerge-r'