### PR TITLE
Safer decompression of vendored Rust crates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
            comment = "see inst/AUTHORS file")
   )
 Description: Provides R bindings to the 'Automerge' Conflict-free
-    Replicated Data Type ('CRDT') library. 'Automerge' enables automatic
+    Replicated Data Type (CRDT) library. 'Automerge' enables automatic
     merging of concurrent changes without conflicts, making it ideal for
     distributed systems, collaborative applications, and offline-first
     architectures.  The package supports all 'Automerge' data types (maps,

--- a/configure
+++ b/configure
@@ -161,7 +161,7 @@ if [ ${AUTOMERGE_FOUND} -eq 0 ]; then
     # Extract vendored Rust dependencies
     if [ -f "src/automerge/rust/vendor.tar.xz" ] && [ ! -d "src/automerge/rust/vendor" ]; then
         echo "Extracting vendored Rust dependencies..."
-        tar -xJf src/automerge/rust/vendor.tar.xz -C src/automerge/rust
+        xz -dc src/automerge/rust/vendor.tar.xz | tar -xf - -C src/automerge/rust
     fi
 
     # Configure Cargo to use vendored sources

--- a/configure.win
+++ b/configure.win
@@ -140,7 +140,7 @@ if [ ${AUTOMERGE_FOUND} -eq 0 ]; then
     # Extract vendored Rust dependencies
     if [ -f "src/automerge/rust/vendor.tar.xz" ] && [ ! -d "src/automerge/rust/vendor" ]; then
         echo "Extracting vendored Rust dependencies..."
-        tar -xJf src/automerge/rust/vendor.tar.xz -C src/automerge/rust
+        xz -dc src/automerge/rust/vendor.tar.xz | tar -xf - -C src/automerge/rust
     fi
 
     # Configure Cargo to use vendored sources

--- a/man/automerge-package.Rd
+++ b/man/automerge-package.Rd
@@ -6,7 +6,7 @@
 \alias{automerge-package}
 \title{automerge: R Bindings for Automerge CRDT Library}
 \description{
-Provides R bindings to the 'Automerge' Conflict-free Replicated Data Type ('CRDT') library. 'Automerge' enables automatic merging of concurrent changes without conflicts, making it ideal for distributed systems, collaborative applications, and offline-first architectures. The package supports all 'Automerge' data types (maps, lists, text, counters) and provides both low-level and high-level synchronization protocols for seamless interoperability with JavaScript and other 'Automerge' implementations.
+Provides R bindings to the 'Automerge' Conflict-free Replicated Data Type (CRDT) library. 'Automerge' enables automatic merging of concurrent changes without conflicts, making it ideal for distributed systems, collaborative applications, and offline-first architectures. The package supports all 'Automerge' data types (maps, lists, text, counters) and provides both low-level and high-level synchronization protocols for seamless interoperability with JavaScript and other 'Automerge' implementations.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
By piping xz to tar. This also used to be required on Solaris...