### PR TITLE
Fix for `ActorId` Valgrind uninitialised value warning

### DIFF
--- a/src/automerge/rust/automerge/src/types.rs
+++ b/src/automerge/rust/automerge/src/types.rs
@@ -41,8 +41,28 @@ const HEAD_STR: &str = "_head";
 // Note that change encoding relies on the Ord implementation for the ActorId being implemented in
 // terms of the lexicographic ordering of the underlying bytes. Be aware of this if you are
 // changing the ActorId implementation in ways which might affect the Ord implementation
-#[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Hash, Clone)]
 pub struct ActorId(TinyVec<[u8; 16]>);
+
+impl PartialEq for ActorId {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for ActorId {}
+
+impl PartialOrd for ActorId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ActorId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_bytes().cmp(other.to_bytes())
+    }
+}
 
 impl fmt::Debug for ActorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -67,6 +87,7 @@ impl ActorId {
         ActorId(TinyVec::from(buf))
     }
 
+    #[inline(never)]
     pub fn to_bytes(&self) -> &[u8] {
         &self.0
     }


### PR DESCRIPTION
Fixes #25.

Replace derived comparison traits on `ActorId` with manual implementations that route through `to_bytes()` marked `#[inline(never)]`:

   ```rust
   #[derive(Hash, Clone)]
   pub struct ActorId(TinyVec<[u8; 16]>);

   impl PartialEq for ActorId {
       fn eq(&self, other: &Self) -> bool {
           self.to_bytes() == other.to_bytes()
       }
   }
   impl Eq for ActorId {}
   impl PartialOrd for ActorId {
       fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
           Some(self.cmp(other))
       }
   }
   impl Ord for ActorId {
       fn cmp(&self, other: &Self) -> Ordering {
           self.to_bytes().cmp(other.to_bytes())
       }
   }
   ```

   ```rust
   #[inline(never)]
   pub fn to_bytes(&self) -> &[u8] {
       &self.0
   }
   ```

The `#[inline(never)]` barrier ensures callers only see a fully-initialised `&[u8]` fat pointer, preventing the compiler from inlining through to the raw `ArrayVec` backing array. Comparison semantics (lexicographic byte ordering) are preserved. 

Performance impact is negligible — `ActorId` comparisons are not on a hot path, and `migrate_actors` is explicitly documented as "an uncommon operation."