### PR TITLE
Add `heads` param to `am_text_content()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # automerge (development version)
 
+* `am_text_content()` gains a `heads` parameter for historical text queries.
+
 * Functions accepting a `heads` parameter now support multiple heads.
 
 * Fixes additional Valgrind false positive in vendored automerge library.

--- a/R/objects.R
+++ b/R/objects.R
@@ -346,6 +346,8 @@ am_text_splice <- function(text_obj, pos, del_count, text) {
 #' Retrieve the full text content from a text object as a string.
 #'
 #' @inheritParams am_text_splice
+#' @param heads Optional list of change hashes (raw vectors) for historical
+#'   query. If `NULL` (default), uses the current state.
 #' @return Character string with the full text
 #' @export
 #' @examples
@@ -359,8 +361,8 @@ am_text_splice <- function(text_obj, pos, del_count, text) {
 #'
 #' am_close(doc)
 #'
-am_text_content <- function(text_obj) {
-  .Call(C_am_text_content, text_obj)
+am_text_content <- function(text_obj, heads = NULL) {
+  .Call(C_am_text_content, text_obj, heads)
 }
 
 #' Update text content

--- a/man/am_text_content.Rd
+++ b/man/am_text_content.Rd
@@ -4,10 +4,13 @@
 \alias{am_text_content}
 \title{Get text content from a text object}
 \usage{
-am_text_content(text_obj)
+am_text_content(text_obj, heads = NULL)
 }
 \arguments{
 \item{text_obj}{An Automerge text object ID}
+
+\item{heads}{Optional list of change hashes (raw vectors) for historical
+query. If \code{NULL} (default), uses the current state.}
 }
 \value{
 Character string with the full text

--- a/src/automerge.h
+++ b/src/automerge.h
@@ -89,7 +89,7 @@ SEXP C_am_keys(SEXP doc_ptr, SEXP obj_ptr);
 SEXP C_am_length(SEXP doc_ptr, SEXP obj_ptr);
 SEXP C_am_insert(SEXP doc_ptr, SEXP obj_ptr, SEXP pos, SEXP value);
 SEXP C_am_text_splice(SEXP text_ptr, SEXP pos, SEXP del_count, SEXP text);
-SEXP C_am_text_content(SEXP text_ptr);
+SEXP C_am_text_content(SEXP text_ptr, SEXP heads);
 SEXP C_am_text_update(SEXP text_ptr, SEXP old_str, SEXP new_str);
 SEXP C_am_values(SEXP doc_ptr, SEXP obj_ptr);
 SEXP C_am_counter_increment(SEXP doc_ptr, SEXP obj_ptr, SEXP key_or_pos, SEXP delta);

--- a/src/init.c
+++ b/src/init.c
@@ -21,7 +21,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_am_length", (DL_FUNC) &C_am_length, 2},
     {"C_am_insert", (DL_FUNC) &C_am_insert, 4},
     {"C_am_text_splice", (DL_FUNC) &C_am_text_splice, 4},
-    {"C_am_text_content", (DL_FUNC) &C_am_text_content, 1},
+    {"C_am_text_content", (DL_FUNC) &C_am_text_content, 2},
     {"C_am_text_update", (DL_FUNC) &C_am_text_update, 3},
     {"C_am_values", (DL_FUNC) &C_am_values, 2},
     {"C_am_counter_increment", (DL_FUNC) &C_am_counter_increment, 4},

--- a/src/objects.c
+++ b/src/objects.c
@@ -599,14 +599,20 @@ SEXP C_am_text_splice(SEXP text_ptr, SEXP pos, SEXP del_count, SEXP text) {
  * Get the full text content from a text object.
  *
  * @param text_ptr External pointer to AMobjId (must be a text object)
+ * @param heads Optional list of change hashes (or R_NilValue)
  * @return Character string with the full text content
  */
-SEXP C_am_text_content(SEXP text_ptr) {
+SEXP C_am_text_content(SEXP text_ptr, SEXP heads) {
     SEXP doc_ptr = get_doc_from_objid(text_ptr);
     AMdoc *doc = get_doc(doc_ptr);
     const AMobjId *text_obj = get_objid(text_ptr);
 
-    AMresult *result = AMtext(doc, text_obj, NULL);
+    AMitems heads_items;
+    AMresult *heads_result = NULL;
+    AMitems *heads_ptr = resolve_heads(heads, &heads_items, &heads_result);
+
+    AMresult *result = AMtext(doc, text_obj, heads_ptr);
+    if (heads_result) AMresultFree(heads_result);
     CHECK_RESULT(result, AM_VAL_TYPE_VOID);
 
     AMitem *item = AMresultItem(result);

--- a/tests/testthat/test-objects.R
+++ b/tests/testthat/test-objects.R
@@ -914,6 +914,54 @@ test_that("am_text_content() returns empty string for empty text", {
   expect_equal(result, "")
 })
 
+test_that("am_text_content() with heads returns historical text", {
+  doc <- am_create()
+  am_put(doc, AM_ROOT, "text", am_text("Hello"))
+  am_commit(doc, "v1")
+  heads_v1 <- am_get_heads(doc)
+
+  text_obj <- am_get(doc, AM_ROOT, "text")
+  am_text_splice(text_obj, 5, 0, " World")
+  am_commit(doc, "v2")
+  heads_v2 <- am_get_heads(doc)
+
+  am_text_splice(text_obj, 11, 0, "!")
+  am_commit(doc, "v3")
+
+  expect_equal(am_text_content(text_obj), "Hello World!")
+  expect_equal(am_text_content(text_obj, heads_v1), "Hello")
+  expect_equal(am_text_content(text_obj, heads_v2), "Hello World")
+  expect_equal(am_text_content(text_obj, NULL), "Hello World!")
+})
+
+test_that("am_text_content() with heads works for empty text state", {
+  doc <- am_create()
+  am_put(doc, AM_ROOT, "text", am_text(""))
+  am_commit(doc, "empty")
+  heads_empty <- am_get_heads(doc)
+
+  text_obj <- am_get(doc, AM_ROOT, "text")
+  am_text_splice(text_obj, 0, 0, "content")
+  am_commit(doc, "filled")
+
+  expect_equal(am_text_content(text_obj, heads_empty), "")
+  expect_equal(am_text_content(text_obj), "content")
+})
+
+test_that("am_text_content() with heads works with unicode", {
+  doc <- am_create()
+  am_put(doc, AM_ROOT, "text", am_text("Hello"))
+  am_commit(doc, "v1")
+  heads_v1 <- am_get_heads(doc)
+
+  text_obj <- am_get(doc, AM_ROOT, "text")
+  am_text_update(text_obj, "Hello", "Hello 🌍")
+  am_commit(doc, "v2")
+
+  expect_equal(am_text_content(text_obj, heads_v1), "Hello")
+  expect_equal(am_text_content(text_obj), "Hello 🌍")
+})
+
 test_that("text objects persist after save/load", {
   doc1 <- am_create()
   am_put(doc1, AM_ROOT, "doc", am_text("Original"))


### PR DESCRIPTION
For historical text queries.